### PR TITLE
Remote plugin bugfix

### DIFF
--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -19,7 +19,7 @@ class BuildIt(object):
     self.builds = {}
     self.builders = self.load_builders()
     self.known_paths = {}
-    self.config = self.load_config()
+    self.config = {}
 
   def load_config(self):
     '''Loads the plugin configuration'''

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -20,9 +20,9 @@ class BuildIt(object):
     self.builders = self.load_builders()
     self.known_paths = {}
     self.config = {
-        'statusloc': 'right',
-        'promptmult': False,
-        'pruneafter': True
+        'statusloc': self.vim.vars.get('buildit_status_location', 'right'),
+        'promptmult': self.vim.vars.get('buildit_prompt_multiple', False),
+        'pruneafter': self.vim.vars.get('buildit_prune_after_status', True),
     }
 
   @neovim.command('BuildIt', sync=True)

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -19,11 +19,17 @@ class BuildIt(object):
     self.builds = {}
     self.builders = self.load_builders()
     self.known_paths = {}
-    self.config = {
-        'statusloc': 'right',
-        'promptmult': False,
-        'pruneafter': True
+    self.config = self.load_config()
+
+  def load_config(self):
+    '''Loads the plugin configuration'''
+    config = {
+        'statusloc': self.vim.vars.get('buildit_status_location', 'right'),
+        'promptmult': self.vim.vars.get('buildit_prompt_multiple', False),
+        'pruneafter': self.vim.vars.get('buildit_prune_after_status', True)
     }
+
+    return config
 
   @neovim.command('BuildIt', sync=True)
   def buildit(self):

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -20,18 +20,18 @@ class BuildIt(object):
     self.builders = self.load_builders()
     self.known_paths = {}
     self.config = {
-        'statusloc': vim.vars.get('buildit_status_location', 'right'),
-        'promptmult': vim.vars.get('buildit_prompt_multiple', False),
-        'pruneafter': vim.vars.get('buildit_prune_after_status', True),
+        'statusloc': 'right',
+        'promptmult': False,
+        'pruneafter': True
     }
 
-  @neovim.command('BuildIt', range='', nargs='*', sync=True)
-  def buildit(self, args, char_range):
+  @neovim.command('BuildIt', sync=True)
+  def buildit(self):
     '''Handles the build-triggering command'''
-    self.start_build(args)
+    self.start_build()
 
   @neovim.function('Build')
-  def start_build(self, args):
+  def start_build(self):
     '''Starts a build'''
     current_buffer = self.vim.current.buffer
     buf_path, fname = os.path.split(current_buffer.name)
@@ -40,8 +40,8 @@ class BuildIt(object):
     ready_func = builder.get('func', None)
     self.add_job(builder_name, build_path, fname, ready_func(build_path) if ready_func else True)
 
-  @neovim.command('BuildItStatus', range='', nargs='*', sync=True)
-  def buildit_status(self, args, char_range):
+  @neovim.command('BuildItStatus', sync=True)
+  def buildit_status(self):
     '''Gets the status of all running builds'''
     statuses = [create_status(build) for build in self.builds.values()]
     location = self.config['statusloc']
@@ -67,8 +67,8 @@ class BuildIt(object):
     if self.config['pruneafter']:
       self.prune()
 
-  @neovim.command('BuildItPrune', range='', nargs='*', sync=True)
-  def prune_builds(self, args, char_range):
+  @neovim.command('BuildItPrune', sync=True)
+  def prune_builds(self):
     '''Handles the build-pruning command'''
     self.prune()
 

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -36,7 +36,7 @@ class BuildIt(object):
     '''Handles the build-triggering command'''
     self.start_build()
 
-  @neovim.function('Build')
+  @neovim.function('Build', sync=False)
   def start_build(self):
     '''Starts a build'''
     if self.config == {}:
@@ -82,7 +82,7 @@ class BuildIt(object):
     '''Handles the build-pruning command'''
     self.prune()
 
-  @neovim.function('Prune')
+  @neovim.function('Prune', sync=False)
   def prune(self):
     '''Remove builds which have failed or finished'''
     for build_key in self.builds:

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -39,6 +39,8 @@ class BuildIt(object):
   @neovim.function('Build')
   def start_build(self):
     '''Starts a build'''
+    if self.config == {}:
+      self.config = self.load_config()
     current_buffer = self.vim.current.buffer
     buf_path, fname = os.path.split(current_buffer.name)
     builder_name, build_path = self.find_builder(buf_path, current_buffer.options['ft'])
@@ -49,6 +51,8 @@ class BuildIt(object):
   @neovim.command('BuildItStatus', sync=True)
   def buildit_status(self):
     '''Gets the status of all running builds'''
+    if self.config == {}:
+      self.config = self.load_config()
     statuses = [create_status(build) for build in self.builds.values()]
     location = self.config['statusloc']
     if location == 'right':

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -20,9 +20,9 @@ class BuildIt(object):
     self.builders = self.load_builders()
     self.known_paths = {}
     self.config = {
-        'statusloc': self.vim.vars.get('buildit_status_location', 'right'),
-        'promptmult': self.vim.vars.get('buildit_prompt_multiple', False),
-        'pruneafter': self.vim.vars.get('buildit_prune_after_status', True),
+        'statusloc': 'right',
+        'promptmult': False,
+        'pruneafter': True
     }
 
   @neovim.command('BuildIt', sync=True)


### PR DESCRIPTION
**Purpose:** Fixes #7 by moving config variable loading out of `__init__`
**Discussion**: I'm not sure why checking configuration variables in `__init__` seems to kill the Python host (which I think is the root cause of the symptom of no remote plugins being registered, as buildit comes first in the list checked). In particular, there seems to be no error caused by checking `buildit_builders` in the `load_builders` method called from `__init__`. However, moving the loading out like this does seem to fix the issue, so I'm closing it for now. I suspect buggy behavior on Neovim's end.