### PR TITLE
Fix CMake problems and make small related improvements

### DIFF
--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -195,7 +195,9 @@ def create_status(build):
   buf_name = build['buffer']
   builder_name = build['builder']
   returncode = build['proc'].poll() if build['proc'] else 1
-  if build['failed'] or (returncode and returncode > 0):
+  if build['failed']:
+    status = "Couldn't start!\t⚠"
+  elif returncode and returncode > 0:
     status = 'Failed\t✖'
   elif returncode == 0:
     status = "Completed\t✔"

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -164,13 +164,11 @@ class BuildIt(object):
     if ready:
       subdir = builder.get('subdir', None)
       execution_dir = os.path.join(build_path, subdir if subdir else '')
-      self.vim.command(f'echom "{execution_dir}"')
-      outfile = TemporaryFile()
       errfile = TemporaryFile()
       proc = Popen(
           shlex.split(builder['cmd']),
           cwd=execution_dir,
-          stdout=outfile,
+          stdout=DEVNULL,
           stderr=errfile,
           shell=builder['shell']
       )
@@ -180,7 +178,6 @@ class BuildIt(object):
         'buffer': fname,
         'failed': not ready,
         'proc': proc,
-        'out': outfile,
         'err': errfile
     }
 

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -31,7 +31,7 @@ class BuildIt(object):
 
     return config
 
-  @neovim.command('BuildIt', sync=True)
+  @neovim.command('BuildIt', sync=False)
   def buildit(self):
     '''Handles the build-triggering command'''
     self.start_build()
@@ -48,7 +48,7 @@ class BuildIt(object):
     ready_func = builder.get('func', None)
     self.add_job(builder_name, build_path, fname, ready_func(build_path) if ready_func else True)
 
-  @neovim.command('BuildItStatus', sync=True)
+  @neovim.command('BuildItStatus', sync=False)
   def buildit_status(self):
     '''Gets the status of all running builds'''
     if self.config == {}:
@@ -77,7 +77,7 @@ class BuildIt(object):
     if self.config['pruneafter']:
       self.prune()
 
-  @neovim.command('BuildItPrune', sync=True)
+  @neovim.command('BuildItPrune', sync=False)
   def prune_builds(self):
     '''Handles the build-pruning command'''
     self.prune()

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -204,14 +204,12 @@ def create_status(build):
   returncode = build['proc'].poll() if build['proc'] else 1
   if build['failed']:
     status = "Couldn't start!\t⚠"
-  elif returncode and returncode > 0:
-    build['out'].seek(0)
-    out = str(build['out'].read(), 'utf-8')
+  elif returncode is not None and returncode > 0:
     build['err'].seek(0)
-    err = str(build['err'].read(), 'utf-8')
-    status = f'Failed\t✖\t{out}\t{err}'
-  elif returncode and returncode == 0:
-    status = f'Completed\t✔\t{out}\t{err}'
+    err = build['err'].read()
+    status = f'Failed\t✖\tError:\t{err}'
+  elif returncode is not None and returncode == 0:
+    status = 'Completed\t✔'
   else:
-    status = "Running..."
+    status = f'Running...Return is {returncode}'
   return f'{buf_name} ({builder_name}): {status}'

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -165,8 +165,9 @@ class BuildIt(object):
       subdir = builder.get('subdir', None)
       execution_dir = os.path.join(build_path, subdir if subdir else '')
       errfile = TemporaryFile()
+      cmd = builder['cmd'] if builder['shell'] else shlex.split(builder['cmd'])
       proc = Popen(
-          shlex.split(builder['cmd']),
+          cmd,
           cwd=execution_dir,
           stdout=DEVNULL,
           stderr=errfile,

--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -85,13 +85,10 @@ class BuildIt(object):
   @neovim.function('Prune', sync=False)
   def prune(self):
     '''Remove builds which have failed or finished'''
+    pruned_builds = dict(self.builds)
     for build_key in self.builds:
       build = self.builds[build_key]
-      pruned_builds = dict(self.builds)
       if build['failed'] or build['proc'].returncode is not None:
-        if build['out'] != DEVNULL:
-          build['out'].close()
-
         if build['err'] != DEVNULL:
           build['err'].close()
 

--- a/rplugin/python3/buildit/builders.py
+++ b/rplugin/python3/buildit/builders.py
@@ -54,7 +54,7 @@ BUILDER_DEFS = {
         'func': None,
         'ft': 'rust',
         'subdir': None,
-        'shell': True
+        'shell': False
     },
     # go build
     # TODO: I'm not sure if we want go build or go install... This also seems like a dumb thing,

--- a/rplugin/python3/buildit/builders.py
+++ b/rplugin/python3/buildit/builders.py
@@ -30,14 +30,22 @@ def oasis_check_build_files(oasis_dir):
 # TODO: More builders!
 BUILDER_DEFS = {
     # make
-    'make': {'sig': r'Makefile', 'cmd': 'make', 'func': None, 'ft': None, 'subdir': None},
+    'make': {
+      'sig': r'Makefile',
+      'cmd': 'make',
+      'func': None,
+      'ft': None,
+      'subdir': None,
+      'shell': False
+    },
     # cmake
     'cmake': {
         'sig': r'CMakeLists\.txt',
         'cmd': 'cmake .. && make',
         'func': cmake_check_build_dir,
         'ft': None,
-        'subdir': 'build'
+        'subdir': 'build',
+        'shell': True
     },
     # cargo
     'cargo': {
@@ -45,19 +53,28 @@ BUILDER_DEFS = {
         'cmd': 'cargo build',
         'func': None,
         'ft': 'rust',
-        'subdir': None
+        'subdir': None,
+        'shell': True
     },
     # go build
     # TODO: I'm not sure if we want go build or go install... This also seems like a dumb thing,
     # having a signature that will match *every* directory. Maybe there's a better option?
-    'go build': {'sig': r'', 'cmd': 'go build', 'func': None, 'ft': 'go', 'subdir': None},
+    'go build': {
+      'sig': r'',
+      'cmd': 'go build',
+      'func': None,
+      'ft': 'go',
+      'subdir': None,
+      'shell': False
+    },
     # stack build
     'stack': {
         'sig': r'stack\.yaml',
         'cmd': 'stack build',
         'func': None,
         'ft': 'haskell',
-        'subdir': None
+        'subdir': None,
+        'shell': False
     },
     # oasis build
     'oasis': {
@@ -65,6 +82,7 @@ BUILDER_DEFS = {
         'cmd': 'make',
         'func': oasis_check_build_files,
         'ft': 'ocaml',
-        'subdir': None
+        'subdir': None,
+        'shell': False
     }
 }

--- a/rplugin/python3/buildit/builders.py
+++ b/rplugin/python3/buildit/builders.py
@@ -31,12 +31,12 @@ def oasis_check_build_files(oasis_dir):
 BUILDER_DEFS = {
     # make
     'make': {
-      'sig': r'Makefile',
-      'cmd': 'make',
-      'func': None,
-      'ft': None,
-      'subdir': None,
-      'shell': False
+        'sig': r'Makefile',
+        'cmd': 'make',
+        'func': None,
+        'ft': None,
+        'subdir': None,
+        'shell': False
     },
     # cmake
     'cmake': {
@@ -60,12 +60,12 @@ BUILDER_DEFS = {
     # TODO: I'm not sure if we want go build or go install... This also seems like a dumb thing,
     # having a signature that will match *every* directory. Maybe there's a better option?
     'go build': {
-      'sig': r'',
-      'cmd': 'go build',
-      'func': None,
-      'ft': 'go',
-      'subdir': None,
-      'shell': False
+        'sig': r'',
+        'cmd': 'go build',
+        'func': None,
+        'ft': 'go',
+        'subdir': None,
+        'shell': False
     },
     # stack build
     'stack': {


### PR DESCRIPTION
The `cmake` builder was not running correctly because its command is defined with shell syntax and we were assuming that builders did not require execution in a shell. This PR adds the ability to run builders in a shell, and also improves upon several smaller items that were discovered in the debugging process. In particular, the conditionals for status generation are improved, an ugly but functional output of error information is added, commands are made async, and a bug in pruning is fixed.