### PR TITLE
Fix stupid error with key error

### DIFF
--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -44,9 +44,12 @@ class BuildIt(object):
     current_buffer = self.vim.current.buffer
     buf_path, fname = os.path.split(current_buffer.name)
     builder_name, build_path = self.find_builder(buf_path, current_buffer.options['ft'])
-    builder = self.builders[builder_name]
-    ready_func = builder.get('func', None)
-    self.add_job(builder_name, build_path, fname, ready_func(build_path) if ready_func else True)
+    if builder_name is None:
+      self.vim.command('echom "No builder found!"')
+    else:
+      builder = self.builders[builder_name]
+      ready_func = builder.get('func', None)
+      self.add_job(builder_name, build_path, fname, ready_func(build_path) if ready_func else True)
 
   @neovim.command('BuildItStatus', sync=False)
   def buildit_status(self):


### PR DESCRIPTION
If you ran the plugin in a directory that had no builder anywhere on its prefix, it would crash.
This is bad. This is a stupid thing to have happen. This is fixed by this patch.