### PR TITLE
Build status reporting

### DIFF
--- a/rplugin/python3/buildit/__init__.py
+++ b/rplugin/python3/buildit/__init__.py
@@ -3,13 +3,15 @@
 import os
 import re
 import shlex
+import sys
 from subprocess import DEVNULL, Popen
 from tempfile import TemporaryFile
 
+import neovim
+
+import asyncio
 from buildit.builders import BUILDER_DEFS
 from buildit.utils import check_ft, create_status
-
-import neovim
 
 
 @neovim.plugin
@@ -21,6 +23,12 @@ class BuildIt(object):
     self.builders = self.load_builders()
     self.known_paths = {}
     self.config = {}
+    if sys.platform == "win32":
+      loop = asyncio.ProactorEventLoop()
+      asyncio.set_event_loop(loop)
+    else:
+      loop = asyncio.get_event_loop()
+    self.loop = loop
 
   def load_config(self):
     '''Loads the plugin configuration'''

--- a/rplugin/python3/buildit/builders/__init__.py
+++ b/rplugin/python3/buildit/builders/__init__.py
@@ -1,11 +1,11 @@
 ''' Standard builder definitions for BuildIt '''
 
-import buildit.builders.cargo as cargo
-import buildit.builders.cmake as cmake
-import buildit.builders.gobuild as gobuild
-import buildit.builders.make as make
-import buildit.builders.oasis as oasis
-import buildit.builders.stack as stack
+from . import cargo
+from . import cmake
+from . import gobuild
+from . import make
+from . import oasis
+from . import stack
 
 BUILDER_DEFS = {
     'cargo': cargo.cargo,

--- a/rplugin/python3/buildit/utils.py
+++ b/rplugin/python3/buildit/utils.py
@@ -14,7 +14,7 @@ def create_status(build):
   '''Builds a status string from a build'''
   buf_name = build['buffer']
   builder_name = build['builder']
-  returncode, err = build['future'].result() if build['future'].done() else (1, None)
+  returncode, err = build['future'].result() if build['future'].done() else (None, None)
   if build['failed']:
     status = "Couldn't start! ⚠"
     error = None

--- a/rplugin/python3/buildit/utils.py
+++ b/rplugin/python3/buildit/utils.py
@@ -11,7 +11,7 @@ def create_status(build):
   '''Builds a status string from a build'''
   buf_name = build['buffer']
   builder_name = build['builder']
-  returncode = build['proc'].poll() if build['proc'] else 1
+  returncode = build['future'].result() if build['future'].done() else 1
   if build['failed']:
     status = "Couldn't start!\t⚠"
     error = None

--- a/rplugin/python3/buildit/utils.py
+++ b/rplugin/python3/buildit/utils.py
@@ -1,5 +1,8 @@
 ''' Utility functions for BuildIt not a part of the main plugin class '''
 
+from subprocess import call, DEVNULL
+from tempfile import TemporaryFile
+
 
 def check_ft(builder, filetype):
   '''Filter function to remove builders that require a certain filetype other than the filetype of
@@ -11,20 +14,31 @@ def create_status(build):
   '''Builds a status string from a build'''
   buf_name = build['buffer']
   builder_name = build['builder']
-  returncode = build['future'].result() if build['future'].done() else 1
+  returncode, err = build['future'].result() if build['future'].done() else (1, None)
   if build['failed']:
-    status = "Couldn't start!\t⚠"
+    status = "Couldn't start! ⚠"
     error = None
   elif returncode is not None and returncode > 0:
-    build['err'].seek(0)
-    err = build['err'].read()
-    status = 'Failed\t✖'
-    error = f'\tError:\t{err}'
+    status = 'Failed ✖'
+    error = f'\tError: {err}'
   elif returncode is not None and returncode == 0:
-    status = 'Completed\t✔'
+    status = 'Completed ✔'
     error = None
   else:
     status = 'Running...'
     error = None
 
   return f'{buf_name} ({builder_name}): {status}', error
+
+
+def run_build(args):
+  '''Run the build command using a subprocess call'''
+  cmd, execution_dir, shell = args
+  errfile = TemporaryFile()
+  result = call(cmd, cwd=execution_dir, stdout=DEVNULL, stderr=errfile, shell=shell)
+  err = None
+  if result != 0:
+    errfile.seek(0)
+    err = errfile.read()
+  errfile.close()
+  return result, err


### PR DESCRIPTION
This restructures the builder running architecture to use a ProcessPoolExecutor and Futures instead of direct Popen subprocesses. This allows us to add a callback to echo a status message on job completion. In so doing, this fixes #11.

This PR does not yet edit the status buffer displayed by BuilditStatus, but I think that's ok - the message that pops up in the statusline seems to get the job of notification done well enough.

I will reopen #11 if the buffer editing functionality proves desirable/is requested.